### PR TITLE
Add timezone hint in cloner docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ services:
         image: orthancteam/python-orthanc-tools:0.6.0
         volumes: ["orthanc-cloner:/status"]
         environment:
+            TZ: "Etc/UTC"
             RUN_ONLY_AT_NIGHT_AND_WEEKEND: "true"
             NIGHT_START_HOUR: "15"
             NIGHT_END_HOUR: "6"

--- a/demo-setups/docker-compose.cloner.yml
+++ b/demo-setups/docker-compose.cloner.yml
@@ -26,6 +26,7 @@ services:
         image: orthancteam/python-orthanc-tools:0.6.1
         volumes: ["orthanc-cloner:/status"]
         environment:
+            TZ: "Etc/UTC"
             RUN_ONLY_AT_NIGHT_AND_WEEKEND: "true"
             NIGHT_START_HOUR: "15"
             NIGHT_END_HOUR: "6"


### PR DESCRIPTION
Setting the timezone is needed for running only at nights and weekends (unless you're in utc time.)