### PR TITLE
Add Orthanc image to auth docker setup

### DIFF
--- a/tests/docker-setup-auth/docker-compose.yml
+++ b/tests/docker-setup-auth/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   orthanc-a:
-    
+    image: orthancteam/orthanc
     ports: ["10042:8042"]
     environment:
       VERBOSE_STARTUP: "true"


### PR DESCRIPTION
Fixes an invalid Docker Compose test setup where `orthanc-a` had no `image` or `build` configured.

The service now uses `orthancteam/orthanc`, matching the other test compose files.

Verified with:

```bash
docker compose -f tests/docker-setup-auth/docker-compose.yml config --quiet