### PR TITLE
Fix HL7 acknowledgements and worklist writes

### DIFF
--- a/orthanc_tools/hl7Lib/hl7_ack.py
+++ b/orthanc_tools/hl7Lib/hl7_ack.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+import random
+from typing import Optional, Union
+
+import hl7
+
+
+def _escape_hl7_text(value: str) -> str:
+    return (
+        value.replace("\\", "\\E\\")
+        .replace("|", "\\F\\")
+        .replace("^", "\\S\\")
+        .replace("~", "\\R\\")
+        .replace("&", "\\T\\")
+        .replace("\r", " ")
+        .replace("\n", " ")
+    )
+
+
+def build_acknowledgement(
+    request: Union[str, hl7.Message],
+    status: str,
+    error_description: Optional[str] = None,
+) -> hl7.Message:
+    if status not in {"AA", "AE", "AR"}:
+        raise ValueError(f"Unsupported HL7 acknowledgment status: {status}")
+
+    hl7_request = request if isinstance(request, hl7.Message) else hl7.parse(request)
+    trigger_event = str(hl7_request["MSH.F9.R1.C2"]) or "O01"
+
+    msh = (
+        "MSH|^~\\&|{sending_application}||{receiving_application}|"
+        "{receiving_facility}|{date_time}||ACK^{trigger_event}|"
+        "{ack_message_id}|P|2.3||||||8859/1"
+    ).format(
+        sending_application=hl7_request["MSH.F5.R1.C1"],
+        receiving_application=hl7_request["MSH.F3.R1.C1"],
+        receiving_facility=hl7_request["MSH.F4.R1.C1"],
+        date_time=datetime.now().strftime("%Y%m%d%H%M%S"),
+        trigger_event=trigger_event,
+        ack_message_id=str(random.randrange(0, 10**15)),
+    )
+    msa = f"MSA|{status}|{hl7_request['MSH.F10.R1.C1']}"
+    if error_description:
+        msa += f"|{_escape_hl7_text(str(error_description))}"
+
+    return hl7.parse(f"{msh}\r{msa}")

--- a/orthanc_tools/hl7Lib/hl7_client.py
+++ b/orthanc_tools/hl7Lib/hl7_client.py
@@ -83,9 +83,9 @@ class MLLPClient:
         Returns: a string with the response (without the sb/eb/cr around the message)
         """
         if isinstance(message, hl7.Message):
-            self.socket.send(self.sb + (str(message)).encode(self.encoding) + self.cr + self.eb + self.cr)
+            self.socket.sendall(self.sb + (str(message)).encode(self.encoding) + self.cr + self.eb + self.cr)
         elif isinstance(message, (bytes, bytearray)):
-            self.socket.send(message)
+            self.socket.sendall(message)
         else:
             raise TypeError('message should be hl7.Message or a bytearray (bytes)')
         return self._receive()

--- a/orthanc_tools/hl7Lib/hl7_dicom_worklist_builder.py
+++ b/orthanc_tools/hl7Lib/hl7_dicom_worklist_builder.py
@@ -1,5 +1,8 @@
 import os
+import re
+import tempfile
 import typing
+from pathlib import Path
 import pydicom
 from enum import Enum
 from typing import List, Union
@@ -124,9 +127,33 @@ class DicomWorklistBuilder:
         ds = self.customize(ds)
 
         if file_name is None:  # if no filename provided, save in the folder
-            file_name = os.path.join(self._folder, "{id}.wl".format(id = ds.AccessionNumber))
+            accession_number = str(ds.AccessionNumber)
+            safe_accession_number = re.sub(r"[^A-Za-z0-9._-]+", "_", accession_number).strip(".")
+            if not safe_accession_number:
+                raise ValueError("AccessionNumber cannot be converted to a safe worklist filename")
 
-        ds.save_as(file_name, enforce_file_format=True)
+            worklist_folder = Path(self._folder).resolve()
+            output_path = (worklist_folder / f"{safe_accession_number}.wl").resolve()
+            if output_path.parent != worklist_folder:
+                raise ValueError("Worklist path must remain inside the configured folder")
+            file_name = os.fspath(output_path)
+
+        output_path = Path(file_name)
+        temp_file_descriptor, temp_file_name = tempfile.mkstemp(
+            dir=output_path.parent,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+        )
+        os.close(temp_file_descriptor)
+        try:
+            ds.save_as(temp_file_name, enforce_file_format=True)
+            os.chmod(temp_file_name, 0o644)
+            os.replace(temp_file_name, output_path)
+        except Exception:
+            if os.path.exists(temp_file_name):
+                os.unlink(temp_file_name)
+            raise
+
         return file_name
 
     def _generate_wl_through_api(self, values: typing.Dict[str, str], entropy_srcs: List[str] = None):

--- a/orthanc_tools/hl7Lib/hl7_orm_worklist_msg_handler.py
+++ b/orthanc_tools/hl7Lib/hl7_orm_worklist_msg_handler.py
@@ -1,8 +1,8 @@
 import os, argparse, sys
 from .hl7_worklist_parser import Hl7WorklistParser
 from .hl7_dicom_worklist_builder import DicomWorklistBuilder
-import hl7, random
-from datetime import datetime
+from .hl7_ack import build_acknowledgement
+import hl7
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,27 +29,30 @@ class Hl7OrmWorklistMsgHandler:
         logger.info("received message:{eol}{message}".format(message = str(message).replace('\r', os.linesep), eol = os.linesep))
         hl7_request = hl7.parse(message)  # we need to parse it here only the build the response
 
+        acknowledge_status = "AE"
+        error_description = None
+
         try:
             values = self._parser.parse(hl7_message = message)
         except Exception as e:
             logger.error("problem during parsing: {exception}".format(exception=e))
             values = None
+            error_description = str(e)
 
         if values is not None:
             try:
                 logger.info(f"generating worklist, ({'file' if self._builder._orthanc_client is None else 'db record'})...")
                 r = self._builder.generate(values)
                 logger.info(f"generated worklist: {r}")
+                acknowledge_status = "AA"
             except Exception as e:
                 logger.error("worklist not generated: {exception}".format(exception=e))
+                error_description = str(e)
 
-        hl7_response = hl7.parse(r'MSH|^~\&|{sending_application}||{receiving_application}|{receiving_facility}|{date_time}||ACK^O01|{ack_message_id}|P|2.3||||||8859/1' + '\r' + 'MSA|AA|{message_id}'.format(  # TODO: handle encoding
-            sending_application = hl7_request['MSH.F5.R1.C1'],
-            receiving_application = hl7_request['MSH.F3.R1.C1'],
-            receiving_facility = hl7_request['MSH.F4.R1.C1'],
-            date_time = datetime.now().strftime("%Y%m%d%H%M%S"),
-            message_id = hl7_request['MSH.F10.R1.C1'],
-            ack_message_id = str(random.randrange(0, 10**15))
-        ))
+        hl7_response = build_acknowledgement(
+            request=hl7_request,
+            status=acknowledge_status,
+            error_description=error_description,
+        )
         logger.info("sending response:{eol}{response}".format(response = str(hl7_response).replace('\r', os.linesep), eol = os.linesep))
         return hl7_response

--- a/orthanc_tools/hl7Lib/hl7_oru_report_msg_handler.py
+++ b/orthanc_tools/hl7Lib/hl7_oru_report_msg_handler.py
@@ -1,8 +1,8 @@
 import os
 from .hl7_report_parser import Hl7ReportParser
 from .hl7_report_series_builder import ReportSeriesBuilder
-import hl7, random
-from datetime import datetime
+from .hl7_ack import build_acknowledgement
+import hl7
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,25 +29,22 @@ class Hl7OruReportMsgHandler:
         logger.info("received message:{eol}{message}".format(message = str(message).replace('\r', os.linesep), eol = os.linesep))
         hl7_request = hl7.parse(message)  # we need to parse it here only the build the response
 
-        values = self._parser.parse(hl7_message = message)
-
-        succeeded = "AE" # "Application Error", there is a problem processing the message. The sending application must correct the problem before attempting to resend the message.
+        acknowledge_status = "AE"
+        error_description = None
 
         try:
+            values = self._parser.parse(hl7_message = message)
             logger.info(f"extracting pdf file... {values['PatientName']}")
             self._builder.generate(values)
-            succeeded = "AA" # Positive acknowledgment: the message was successfully processed.
+            acknowledge_status = "AA"
         except Exception as e:
             logger.error("pdf not added to the study: {exception}".format(exception=e))
+            error_description = str(e)
 
-        hl7_response = hl7.parse(r'MSH|^~\&|{sending_application}||{receiving_application}|{receiving_facility}|{date_time}||ACK^O01|{ack_message_id}|P|2.3||||||8859/1' + '\rMSA|{acknowledge_status}|{message_id}'.format(  # TODO: handle encoding
-            sending_application = hl7_request['MSH.F5.R1.C1'],
-            receiving_application = hl7_request['MSH.F3.R1.C1'],
-            receiving_facility = hl7_request['MSH.F4.R1.C1'],
-            date_time = datetime.now().strftime("%Y%m%d%H%M%S"),
-            message_id = hl7_request['MSH.F10.R1.C1'],
-            acknowledge_status = succeeded,
-            ack_message_id = str(random.randrange(0, 10**15))
-        ))
+        hl7_response = build_acknowledgement(
+            request=hl7_request,
+            status=acknowledge_status,
+            error_description=error_description,
+        )
         logger.info("sending response:{eol}{response}".format(response = str(hl7_response).replace('\r', os.linesep), eol = os.linesep))
         return hl7_response

--- a/orthanc_tools/hl7Lib/hl7_server.py
+++ b/orthanc_tools/hl7Lib/hl7_server.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-import random
 import socketserver, subprocess, sys, re, socket
 from threading import Thread
 #from hl7Lib import Hl7MessageValidator, UnsupportedMessageType, InvalidHL7Message
 from .hl7_message_validator import Hl7MessageValidator
 from .hl7_error import UnsupportedMessageType, InvalidHL7Message
+from .hl7_ack import build_acknowledgement
 import hl7
 import logging
 
@@ -115,7 +114,7 @@ class _Hl7MllpRequestHandler(socketserver.StreamRequestHandler):
             except KeyError:
                 raise e
             else:
-                response = errHandler(msg, error_description = str(e), *args)
+                response = errHandler(msg, *args, error_description=str(e))
                 return response
 
 
@@ -216,20 +215,12 @@ class MLLPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
 def default_message_handler(message):
     return NotImplementedError("Please implement a message handler.")
 
-def handle_error_message(self, message: str, error_description: str = None) -> hl7.Message:
-
-    hl7_request = hl7.parse(message)  # we need to re-parse it here only the build the response
-
-    hl7_response = hl7.parse(r'MSH|^~\&|{sending_application}||{receiving_application}|{receiving_facility}|{date_time}||ACK^O01|{ack_message_id}|P|2.3||||||8859/1' + '\rMSA|AR|{message_id}|{error}'.format(  # TODO: handle encoding
-        sending_application = hl7_request['MSH.F5.R1.C1'],
-        receiving_application = hl7_request['MSH.F3.R1.C1'],
-        receiving_facility = hl7_request['MSH.F4.R1.C1'],
-        date_time = datetime.now().strftime("%Y%m%d%H%M%S"),
-        message_id = hl7_request['MSH.F10.R1.C1'],
-        ack_message_id = str(random.randrange(0, 10 ** 15)),
-        error = error_description
-    ))
-    return hl7_response
+def handle_error_message(message: str, error_description: str = None) -> hl7.Message:
+    return build_acknowledgement(
+        request=message,
+        status="AR",
+        error_description=error_description,
+    )
 
 # this is just a very quick usage example that does nothing usefull since it uses abstract handler
 if __name__ == "__main__":

--- a/orthanc_tools/hl7Lib/tests/test_hl7_safety.py
+++ b/orthanc_tools/hl7Lib/tests/test_hl7_safety.py
@@ -1,0 +1,171 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import hl7
+import pydicom
+
+from orthanc_tools.hl7Lib.hl7_client import MLLPClient
+from orthanc_tools.hl7Lib.hl7_dicom_worklist_builder import DicomWorklistBuilder
+from orthanc_tools.hl7Lib.hl7_orm_worklist_msg_handler import Hl7OrmWorklistMsgHandler
+from orthanc_tools.hl7Lib.hl7_oru_report_msg_handler import Hl7OruReportMsgHandler
+from orthanc_tools.hl7Lib.hl7_server import handle_error_message
+
+
+ORM_MESSAGE = (
+    r"MSH|^~\&|SENDER|FACILITY|RECEIVER|DESTINATION|20260730120000||"
+    "ORM^O01|orm-message-id|P|2.3\rPID|1"
+)
+ORU_MESSAGE = (
+    r"MSH|^~\&|SENDER|FACILITY|RECEIVER|DESTINATION|20260730120000||"
+    "ORU^R01|oru-message-id|P|2.3\rPID|1"
+)
+
+
+class FakeParser:
+    def __init__(self, result=None, error=None):
+        self._result = result or {}
+        self._error = error
+
+    def parse(self, hl7_message):
+        if self._error:
+            raise self._error
+        return self._result
+
+
+class FakeBuilder:
+    _folder = "unused"
+    _orthanc_client = None
+
+    def __init__(self, error=None):
+        self._error = error
+
+    def generate(self, values):
+        if self._error:
+            raise self._error
+        return "generated"
+
+
+class TestHl7Acknowledgements(unittest.TestCase):
+    def test_orm_success_acknowledgement_has_formatted_header(self):
+        handler = Hl7OrmWorklistMsgHandler(
+            parser=FakeParser(),
+            builder=FakeBuilder(),
+        )
+
+        response = handler.handle_orm_message(ORM_MESSAGE)
+
+        self.assertEqual("AA", response["MSA.F1.R1"])
+        self.assertEqual("orm-message-id", response["MSA.F2.R1"])
+        self.assertEqual("RECEIVER", response["MSH.F3.R1"])
+        self.assertEqual("ACK", response["MSH.F9.R1.C1"])
+        self.assertEqual("O01", response["MSH.F9.R1.C2"])
+        self.assertNotIn("{sending_application}", str(response))
+
+    def test_orm_parser_failure_returns_application_error(self):
+        handler = Hl7OrmWorklistMsgHandler(
+            parser=FakeParser(error=ValueError("invalid order")),
+            builder=FakeBuilder(),
+        )
+
+        response = handler.handle_orm_message(ORM_MESSAGE)
+
+        self.assertEqual("AE", response["MSA.F1.R1"])
+        self.assertEqual("invalid order", response["MSA.F3.R1"])
+
+    def test_orm_builder_failure_returns_application_error(self):
+        handler = Hl7OrmWorklistMsgHandler(
+            parser=FakeParser(),
+            builder=FakeBuilder(error=RuntimeError("disk full")),
+        )
+
+        response = handler.handle_orm_message(ORM_MESSAGE)
+
+        self.assertEqual("AE", response["MSA.F1.R1"])
+        self.assertEqual("disk full", response["MSA.F3.R1"])
+
+    def test_oru_parser_failure_returns_application_error_for_r01(self):
+        handler = Hl7OruReportMsgHandler(
+            parser=FakeParser(error=ValueError("invalid report")),
+            builder=FakeBuilder(),
+        )
+
+        response = handler.handle_oru_message(ORU_MESSAGE)
+
+        self.assertEqual("AE", response["MSA.F1.R1"])
+        self.assertEqual("ACK", response["MSH.F9.R1.C1"])
+        self.assertEqual("R01", response["MSH.F9.R1.C2"])
+
+    def test_default_error_handler_is_directly_callable(self):
+        response = handle_error_message(
+            ORM_MESSAGE,
+            error_description="unsupported | message",
+        )
+
+        self.assertEqual("AR", response["MSA.F1.R1"])
+        self.assertEqual("unsupported | message", response["MSA.F3.R1"])
+
+
+class TestMllpClientWrites(unittest.TestCase):
+    def test_send_uses_sendall(self):
+        client = object.__new__(MLLPClient)
+        client.encoding = "iso-8859-1"
+        client.sb = b"\x0b"
+        client.eb = b"\x1c"
+        client.cr = b"\r"
+        client.socket = mock.Mock()
+        client._receive = mock.Mock(return_value="response")
+        message = hl7.parse(ORM_MESSAGE)
+
+        self.assertEqual("response", client.send(message))
+
+        client.socket.sendall.assert_called_once()
+        client.socket.send.assert_not_called()
+
+
+class TestWorklistFileSafety(unittest.TestCase):
+    @staticmethod
+    def _values(accession_number):
+        return {
+            "AccessionNumber": accession_number,
+            "PatientID": "patient",
+            "PatientName": "Patient^Test",
+            "PatientBirthDate": "20000101",
+            "PatientSex": "O",
+            "RequestedProcedureID": "procedure",
+            "SpecificCharacterSet": "ISO_IR 100",
+            "ScheduledStationAETitle": "ORTHANC",
+            "ScheduledProcedureStepID": "step",
+        }
+
+    def test_accession_number_cannot_escape_worklist_folder(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            builder = DicomWorklistBuilder(folder=temporary_dir)
+
+            file_name = builder.generate(self._values("../outside"))
+
+            self.assertEqual(
+                os.path.realpath(temporary_dir),
+                os.path.dirname(os.path.realpath(file_name)),
+            )
+            self.assertTrue(os.path.isfile(file_name))
+            self.assertFalse(os.path.exists(os.path.join(temporary_dir, "..", "outside.wl")))
+
+    def test_failed_write_does_not_leave_partial_file(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            builder = DicomWorklistBuilder(folder=temporary_dir)
+
+            with mock.patch.object(
+                pydicom.dataset.FileDataset,
+                "save_as",
+                side_effect=RuntimeError("write failed"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "write failed"):
+                    builder.generate(self._values("safe-accession"))
+
+            self.assertEqual([], os.listdir(temporary_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- centralizes HL7 ACK construction for ORM, ORU, and server errors
- returns `AE` when parsing, worklist generation, or report generation fails
- generates the matching ACK trigger event (`O01` or `R01`) with fully formatted MSH fields
- fixes the default MLLP error-handler signature
- uses `sendall()` so MLLP messages cannot be truncated by partial socket writes
- sanitizes AccessionNumber-derived worklist filenames
- writes worklist files atomically and removes temporary files after failures

## Why

The three ACK implementations formatted only the MSA segment, leaving literal placeholders in MSH. The ORM handler also returned `AA` after parser or builder failures. Separately, network-supplied accession numbers could escape the configured worklist folder, and direct writes could leave a partial `.wl` file visible to Orthanc.

## Impact

Senders now receive truthful, correctly addressed acknowledgments. Failed worklists remain retryable, MLLP writes are complete, and folder-backed worklists cannot traverse outside their configured directory or become visible half-written.

## Validation

- 39 non-Orthanc HL7 tests passed in the Python 3.14 project image
- production-style Docker image build passed
- the installed package imports the new ACK helper successfully
- `git diff --check` passed

No production services were contacted or changed.
