### PR TITLE
Harden runtime tools against unsafe failures

### DIFF
--- a/orthanc_tools/helpers/environment.py
+++ b/orthanc_tools/helpers/environment.py
@@ -1,0 +1,24 @@
+import os
+from typing import Optional
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def get_env_bool(name: str, default: Optional[bool] = False) -> Optional[bool]:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    normalized_value = value.strip().lower()
+    if normalized_value in TRUE_VALUES:
+        return True
+    if normalized_value in FALSE_VALUES:
+        return False
+
+    allowed_values = sorted(TRUE_VALUES | FALSE_VALUES)
+    raise ValueError(
+        f"Invalid boolean value for environment variable {name}: {value!r}. "
+        f"Expected one of {allowed_values}."
+    )

--- a/orthanc_tools/helpers/old_files_deleter.py
+++ b/orthanc_tools/helpers/old_files_deleter.py
@@ -2,7 +2,6 @@ import typing
 import time
 import glob
 import os
-from .time_out import TimeOut
 import threading
 import logging
 
@@ -29,6 +28,7 @@ class OldFilesDeleter:
         self._recursive = recursive
         self._thread = None
         self._execution_count = 0 # mainly used in unit tests
+        self._stop_event = threading.Event()
 
     def execute_once(self):
         self._execution_count += 1
@@ -41,6 +41,9 @@ class OldFilesDeleter:
             glob_filter = os.path.join(self._folder_to_monitor, '**/', self._filter)
 
         for file_path in glob.glob(glob_filter, recursive = self._recursive):
+            if not os.path.isfile(file_path):
+                continue
+
             last_modification_time = os.path.getmtime(file_path)
             if last_modification_time < oldest_time:
                 logger.debug("deleting {file_path}".format(file_path = file_path))
@@ -51,16 +54,14 @@ class OldFilesDeleter:
 
     def execute(self):
         self._is_running = True
-        timeout = TimeOut(self._execution_interval)
 
         # execute once at startup and then every X
         self.execute_once()
 
-        while self._is_running:
-            while self._is_running and not timeout.is_expired():
-                time.sleep(min(1, self._execution_interval))
+        while not self._stop_event.wait(self._execution_interval):
             self.execute_once()
-            timeout.reset()
+
+        self._is_running = False
 
     def __enter__(self):
         self.start()
@@ -72,6 +73,11 @@ class OldFilesDeleter:
     def start(self):
         logger.info("Starting old files deleter ({folder})".format(folder = self._folder_to_monitor))
 
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("Old files deleter is already running")
+
+        self._stop_event.clear()
+
         # create monitoring thread
         self._thread = threading.Thread(
             target = self.execute,
@@ -81,5 +87,7 @@ class OldFilesDeleter:
 
     def stop(self):
         logger.info("Stopping old files deleter ({folder})".format(folder = self._folder_to_monitor))
-        self._is_running = False
-        self._thread.join()
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None

--- a/orthanc_tools/orthanc_comparator.py
+++ b/orthanc_tools/orthanc_comparator.py
@@ -3,6 +3,7 @@ import logging
 import argparse
 import datetime
 from .helpers.scheduler import Scheduler
+from .helpers.environment import get_env_bool
 from orthanc_api_client import helpers
 import logging
 from orthanc_api_client import OrthancApiClient
@@ -399,10 +400,10 @@ if __name__ == '__main__':
     level = os.environ.get("LEVEL", args.level)
     from_study_date = helpers.from_dicom_date(os.environ.get("FROM_STUDY_DATE", args.from_study_date))
     to_study_date = helpers.from_dicom_date(os.environ.get("TO_STUDY_DATE", args.to_study_date))
-    transfer_missing_to_modality = os.environ.get("TRANSFER_MISSING_TO_MODALITY", args.transfer_missing_to_modality)
-    ignore_missing_from_orthanc = os.environ.get("IGNORE_MISSING_FROM_ORTHANC", args.ignore_missing_from_orthanc)
-    retrieve_missing_from_orthanc = os.environ.get("RETRIEVE_MISSING_FROM_ORTHANC", args.retrieve_missing_from_orthanc)
-    ignore_missing_on_modality = os.environ.get("IGNORE_MISSING_ON_MODALITY", args.ignore_missing_on_modality)
+    transfer_missing_to_modality = get_env_bool("TRANSFER_MISSING_TO_MODALITY", args.transfer_missing_to_modality)
+    ignore_missing_from_orthanc = get_env_bool("IGNORE_MISSING_FROM_ORTHANC", args.ignore_missing_from_orthanc)
+    retrieve_missing_from_orthanc = get_env_bool("RETRIEVE_MISSING_FROM_ORTHANC", args.retrieve_missing_from_orthanc)
+    ignore_missing_on_modality = get_env_bool("IGNORE_MISSING_ON_MODALITY", args.ignore_missing_on_modality)
     error_log_file_path = os.environ.get("ERROR_LOG_FILE_PATH", args.error_log_file_path)
     days_to_compare = os.environ.get("DAYS_TO_COMPARE", args.days_to_compare)
     if days_to_compare is not None:

--- a/orthanc_tools/orthanc_monitor.py
+++ b/orthanc_tools/orthanc_monitor.py
@@ -223,7 +223,7 @@ class OrthancMonitor:
                         processed = True
 
                 except Exception as ex:
-                    logger.exception("Unhandled exception in event handler: ", ex)
+                    logger.exception("Unhandled exception in event handler: %s", ex)
                     last_error = str(ex)
 
                 retries = retries + 1

--- a/orthanc_tools/orthanc_syncher.py
+++ b/orthanc_tools/orthanc_syncher.py
@@ -1,15 +1,16 @@
-import os, time
-import logging
 import argparse
-import tempfile
 import datetime
+import logging
+import os
+import tempfile
+import time
 from typing import List
 
-from .helpers.scheduler import Scheduler
 from orthanc_api_client import helpers
-import logging
 from orthanc_api_client import OrthancApiClient
 import schedule
+
+from .helpers.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -95,12 +96,12 @@ class OrthancSyncher:
 
             # ...finally, if nothing is in the args, we will process the entire content of Orthanc...
             else:
-                self._run_till_last_update_1 = datetime.datetime(year=2025, month=1, day=1, hour=1, minute=1, second=1)
+                self._run_till_last_update_1 = self._initial_last_update()
 
             if run_till_last_update_2 is not None:
                 self._run_till_last_update_2 = run_till_last_update_2
             else:
-                self._run_till_last_update_2 = datetime.datetime(year=2025, month=1, day=1, hour=1, minute=1, second=1)
+                self._run_till_last_update_2 = self._initial_last_update()
 
         self._execution_time = execution_time
         self._execution_day = execution_day
@@ -110,6 +111,33 @@ class OrthancSyncher:
             self._periodic_mode_enabled = True
 
         self._batch_size = orthanc_queries_batch_size
+
+    @staticmethod
+    def _initial_last_update():
+        return datetime.datetime(year=1950, month=1, day=1, hour=1, minute=1, second=1)
+
+    def _write_status_values(self, last_update_values):
+        status_path = os.path.abspath(self._persist_status_path)
+        status_folder = os.path.dirname(status_path)
+        temp_file_descriptor, temp_file_path = tempfile.mkstemp(
+            dir=status_folder,
+            prefix=f".{os.path.basename(status_path)}.",
+            suffix=".tmp",
+            text=True,
+        )
+        try:
+            with os.fdopen(temp_file_descriptor, "w") as status_file:
+                status_file.writelines(
+                    datetime.datetime.strftime(value, "%Y-%m-%d %H:%M:%S") + "\n"
+                    for value in last_update_values
+                )
+                status_file.flush()
+                os.fsync(status_file.fileno())
+            os.replace(temp_file_path, status_path)
+        except Exception:
+            if os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+            raise
 
     def _read_status_from_file(self):
         """
@@ -122,17 +150,17 @@ class OrthancSyncher:
         try:
             with open(self._persist_status_path) as f:
                 last_update_strings = f.read().splitlines()
-        except (ValueError, FileNotFoundError):  # if can not read, use 1-1-1950
+
+            if len(last_update_strings) != 2:
+                raise ValueError("Status file must contain exactly two LastUpdate values")
+
+            last_update_1 = datetime.datetime.strptime(last_update_strings[0], "%Y-%m-%d %H:%M:%S")
+            last_update_2 = datetime.datetime.strptime(last_update_strings[1], "%Y-%m-%d %H:%M:%S")
+        except (OSError, ValueError):  # if can not read, use 1-1-1950
             logger.warning("Could not read LastUpdate values from file, running till at 01-01-1950")
-            first_january_1950 = datetime.datetime(year=1950, month=1, day=1, hour=1, minute=1, second=1)
-
-            with open(self._persist_status_path, 'w') as f:
-                full_line = datetime.datetime.strftime(first_january_1950, "%Y-%m-%d %H:%M:%S") + '\n'
-                f.writelines([full_line, full_line])
+            first_january_1950 = self._initial_last_update()
+            self._write_status_values([first_january_1950, first_january_1950])
             return first_january_1950, first_january_1950
-
-        last_update_1 = datetime.datetime.strptime(last_update_strings[0], "%Y-%m-%d %H:%M:%S")
-        last_update_2 = datetime.datetime.strptime(last_update_strings[1], "%Y-%m-%d %H:%M:%S")
 
         logger.info(f"Orthanc-1 till value from file = {last_update_1}")
         logger.info(f"Orthanc-2 till value from file = {last_update_2}")
@@ -185,12 +213,18 @@ class OrthancSyncher:
 
         index=0
         while True:
+            if self._scheduler:
+                self._scheduler.wait_right_time_to_run()
+
             # Get a batch of studies
             studies = self.get_studies(orthanc_client=orthanc_source, batch_size=self._batch_size, index=index)
 
             logger.info(f"[{self._current_run}] Processing batch index {index}...")
 
             if index == 0:
+                if len(studies) == 0:
+                    logger.info(f"[{self._current_run}] No studies found, end of this run!")
+                    return last_update_limit
                 new_last_update_limit = studies[0].last_update
 
             for study in studies:
@@ -218,16 +252,18 @@ class OrthancSyncher:
             with open(self._persist_status_path, 'r') as f:
                 last_update_strings = f.read().splitlines()
 
-            # replace values
-            last_update_strings[index] = datetime.datetime.strftime(new_last_update_value, "%Y-%m-%d %H:%M:%S")
+            if len(last_update_strings) != 2:
+                raise ValueError("Status file must contain exactly two LastUpdate values")
 
-            # write file
-            with open(self._persist_status_path, 'w') as f:
-                f.writelines(line + '\n' for line in last_update_strings)
+            last_update_values = [
+                datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+                for value in last_update_strings
+            ]
+            last_update_values[index] = new_last_update_value
+            self._write_status_values(last_update_values)
 
-        except (ValueError, FileNotFoundError):
-            logger.error("Could not write LastUpdate values to file!")
-            exit(0)
+        except (OSError, ValueError, IndexError) as ex:
+            raise RuntimeError("Could not write LastUpdate values to file") from ex
 
     def compare_studies(self, orthanc_source: OrthancApiClient, orthanc_destination: OrthancApiClient, orthanc_study_id):
         # check if study is in distant Orthanc
@@ -254,6 +290,10 @@ class OrthancSyncher:
 
     def transfer_instances(self, orthanc_source: OrthancApiClient, orthanc_destination: OrthancApiClient, instances_ids: List[str]):
 
+        if len(instances_ids) == 0:
+            logger.info("No instances to transfer")
+            return
+
         retry_count = 0
         retry_delays = [5, 20, 60, 300, 900, 1800, 3600, 7200]
 
@@ -273,7 +313,7 @@ class OrthancSyncher:
             except Exception as e:
                 if retry_count == 5:
                     logger.error(f"Error while transfering a resource from this study: {orthanc_source.instances.get_parent_study_id(instances_ids[0])}. Exception: {str(e)}")
-                    exit(0)
+                    raise RuntimeError("Could not transfer instances after 6 attempts") from e
                 else:
                     retry_count += 1
                     logger.warning(f"Error while transfering a resource from this study: {orthanc_source.instances.get_parent_study_id(instances_ids[0])}. Exception: {str(e)}")

--- a/orthanc_tools/orthanc_uploader.py
+++ b/orthanc_tools/orthanc_uploader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import logging
 import argparse
 from orthanc_api_client import OrthancApiClient
-import os, time, sys
+import os, time
 import zipfile
 import tempfile
 
@@ -73,19 +73,20 @@ class OrthancUploader:
                             time.sleep(delay)
                         try:
                             # here, we should have only files (and no zip file)
-                            instance_orthanc_ids = orthanc_client.upload_file(full_path, ignore_errors=True)
+                            instance_orthanc_ids = self._api_client.upload_file(full_path, ignore_errors=True)
                             if len(instance_orthanc_ids) == 0:
                                 logger.error(f"File not uploaded: {full_path}.")
                                 break
-                            study_orthanc_id = orthanc_client.instances.get_parent_study_id(instance_orthanc_ids[0])
-                            orthanc_client.studies.add_labels(orthanc_id=study_orthanc_id, labels=labels_list)
+                            study_orthanc_id = self._api_client.instances.get_parent_study_id(instance_orthanc_ids[0])
+                            self._api_client.studies.add_labels(orthanc_id=study_orthanc_id, labels=labels_list)
                             break
                         except Exception as e:
                             retry_count += 1
                             if retry_count == 8:
                                 logger.error(f"Error while uploading this file: {full_path}. Exception: {str(e)}")
-                                logger.error(f"too many attempts, exiting...")
-                                sys.exit(1)
+                                raise RuntimeError(
+                                    f"Too many attempts while uploading {full_path}"
+                                ) from e
                             else:
                                 logger.warning(f"Error while uploading this file, retrying...: {full_path}. Exception: {str(e)}")
             elif os.path.isdir(full_path):
@@ -97,7 +98,7 @@ class OrthancUploader:
         folder_path = self.get_folder(Path(self._path))
 
         # let's get the existing labels
-        labels_list = orthanc_client.get_all_labels()
+        labels_list = self._api_client.get_all_labels()
         orthanc_labels_chosen_list = []
 
         # let the user choose the labels to apply among the existing ones

--- a/orthanc_tools/orthanc_warmer.py
+++ b/orthanc_tools/orthanc_warmer.py
@@ -23,7 +23,7 @@ class OrthancWarmer:
 
     def find(self):
         try:
-            o.studies.find(query={'StudyDate': "19500101"})
+            self._api_client.studies.find(query={'StudyDate': "19500101"})
             # 1st of January 1950 is sunday, so probably no results
             self._errors_counter = 0
             logger.debug("Find succeeded!")
@@ -38,7 +38,7 @@ class OrthancWarmer:
 
     def execute(self):
         logger.info("----- Initializing Orthanc Warmer...")
-        schedule.every(interval).minutes.do(self.find)
+        schedule.every(self._interval).minutes.do(self.find)
 
         while True:
             schedule.run_pending()

--- a/tests/test_old_files_deleter.py
+++ b/tests/test_old_files_deleter.py
@@ -59,6 +59,22 @@ class TestOldFilesDeleter(TestCase):
             self.assertFalse(os.path.exists(sub_txt_file_path))
             self.assertTrue(os.path.exists(bin_file_path))
 
+    def test_default_filter_ignores_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sub_dir_path = os.path.join(temp_dir, 'subdir')
+            os.mkdir(sub_dir_path)
+            old_file_path = os.path.join(sub_dir_path, 'old.txt')
+            Path(old_file_path).touch()
+            time.sleep(0.2)
+
+            OldFilesDeleter(
+                folder_to_monitor=temp_dir,
+                timeout=0.1,
+            ).execute_once()
+
+            self.assertTrue(os.path.isdir(sub_dir_path))
+            self.assertFalse(os.path.exists(old_file_path))
+
     def test_not_recursive(self):
 
         with tempfile.TemporaryDirectory() as tempDir:

--- a/tests/test_runtime_correctness.py
+++ b/tests/test_runtime_correctness.py
@@ -3,9 +3,11 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from orthanc_tools.helpers.environment import get_env_bool
+from orthanc_tools.orthanc_monitor import OrthancMonitor
 from orthanc_tools.orthanc_syncher import OrthancSyncher
 from orthanc_tools.orthanc_uploader import OrthancUploader
 from orthanc_tools.orthanc_warmer import OrthancWarmer
@@ -125,6 +127,35 @@ class TestOrthancSyncherSafety(unittest.TestCase):
                 )
 
         self.assertEqual(6, source.instances.get_file.call_count)
+
+
+class TestOrthancMonitorLogging(unittest.TestCase):
+    def test_handler_exception_is_logged_without_masking_original_error(self):
+        monitor = OrthancMonitor(api_client=mock.MagicMock(), max_retries=0)
+        change_type = mock.sentinel.change_type
+        monitor.add_handler(
+            change_type,
+            mock.Mock(side_effect=RuntimeError("handler failed")),
+        )
+        monitor._changes_to_process.put(
+            SimpleNamespace(
+                sequence_id=42,
+                resource_id="resource-id",
+                change_type=change_type,
+            )
+        )
+        monitor._changes_to_process.put(None)
+
+        with self.assertLogs(
+            "orthanc_tools.orthanc_monitor",
+            level="ERROR",
+        ) as captured:
+            monitor._process_changes(worker_id=0)
+
+        self.assertIn(
+            "Unhandled exception in event handler: handler failed",
+            captured.output[0],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_correctness.py
+++ b/tests/test_runtime_correctness.py
@@ -1,0 +1,131 @@
+import datetime
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orthanc_tools.helpers.environment import get_env_bool
+from orthanc_tools.orthanc_syncher import OrthancSyncher
+from orthanc_tools.orthanc_uploader import OrthancUploader
+from orthanc_tools.orthanc_warmer import OrthancWarmer
+
+
+class TestBooleanEnvironmentVariables(unittest.TestCase):
+    def test_false_string_is_false(self):
+        with mock.patch.dict(os.environ, {"FEATURE_ENABLED": "false"}):
+            self.assertFalse(get_env_bool("FEATURE_ENABLED", True))
+
+    def test_true_values_are_case_insensitive(self):
+        with mock.patch.dict(os.environ, {"FEATURE_ENABLED": "YeS"}):
+            self.assertTrue(get_env_bool("FEATURE_ENABLED"))
+
+    def test_missing_value_uses_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(get_env_bool("FEATURE_ENABLED", True))
+
+    def test_invalid_value_is_rejected(self):
+        with mock.patch.dict(os.environ, {"FEATURE_ENABLED": "sometimes"}):
+            with self.assertRaisesRegex(ValueError, "FEATURE_ENABLED"):
+                get_env_bool("FEATURE_ENABLED")
+
+
+class TestInjectedApiClients(unittest.TestCase):
+    def test_uploader_uses_injected_client(self):
+        api_client = mock.MagicMock()
+        api_client.upload_file.return_value = ["instance-id"]
+        api_client.instances.get_parent_study_id.return_value = "study-id"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "instance.dcm").touch()
+            uploader = OrthancUploader(api_client=api_client, path=temp_dir)
+
+            uploader.upload_folder_and_label(temp_dir, ["reviewed"])
+
+        api_client.upload_file.assert_called_once()
+        api_client.instances.get_parent_study_id.assert_called_once_with("instance-id")
+        api_client.studies.add_labels.assert_called_once_with(
+            orthanc_id="study-id",
+            labels=["reviewed"],
+        )
+
+    def test_warmer_uses_injected_client(self):
+        api_client = mock.MagicMock()
+        warmer = OrthancWarmer(api_client=api_client, interval=30)
+
+        warmer.find()
+
+        api_client.studies.find.assert_called_once_with(
+            query={"StudyDate": "19500101"}
+        )
+        self.assertEqual(0, warmer._errors_counter)
+
+
+class TestOrthancSyncherSafety(unittest.TestCase):
+    def _syncher(self, **kwargs):
+        return OrthancSyncher(
+            api_client_1=mock.MagicMock(),
+            api_client_2=mock.MagicMock(),
+            **kwargs,
+        )
+
+    def test_empty_source_preserves_last_update_limit(self):
+        last_update_limit = datetime.datetime(2026, 7, 30, 12, 0, 0)
+        syncher = self._syncher()
+        syncher.get_studies = mock.Mock(return_value=[])
+
+        result = syncher.synch(
+            orthanc_source=mock.sentinel.source,
+            orthanc_destination=mock.sentinel.destination,
+            last_update_limit=last_update_limit,
+        )
+
+        self.assertEqual(last_update_limit, result)
+
+    def test_scheduler_is_checked_before_querying_a_batch(self):
+        scheduler = mock.Mock()
+        syncher = self._syncher(scheduler=scheduler)
+        syncher.get_studies = mock.Mock(return_value=[])
+
+        syncher.synch(
+            orthanc_source=mock.sentinel.source,
+            orthanc_destination=mock.sentinel.destination,
+            last_update_limit=datetime.datetime(2026, 7, 30, 12, 0, 0),
+        )
+
+        scheduler.wait_right_time_to_run.assert_called_once_with()
+
+    def test_invalid_status_file_is_reinitialized_atomically(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            status_path = os.path.join(temp_dir, "status.txt")
+            Path(status_path).write_text("truncated\n", encoding="utf-8")
+
+            syncher = self._syncher(persist_status_path=status_path)
+
+            self.assertEqual(syncher._initial_last_update(), syncher._run_till_last_update_1)
+            self.assertEqual(syncher._initial_last_update(), syncher._run_till_last_update_2)
+            self.assertEqual(
+                ["1950-01-01 01:01:01", "1950-01-01 01:01:01"],
+                Path(status_path).read_text(encoding="utf-8").splitlines(),
+            )
+            self.assertEqual(["status.txt"], os.listdir(temp_dir))
+
+    def test_transfer_failure_raises_instead_of_exiting_process(self):
+        source = mock.MagicMock()
+        source.instances.get_file.side_effect = RuntimeError("offline")
+        source.instances.get_parent_study_id.return_value = "study-id"
+        syncher = self._syncher()
+
+        with mock.patch("orthanc_tools.orthanc_syncher.time.sleep"):
+            with self.assertRaisesRegex(RuntimeError, "6 attempts"):
+                syncher.transfer_instances(
+                    orthanc_source=source,
+                    orthanc_destination=mock.MagicMock(),
+                    instances_ids=["instance-id"],
+                )
+
+        self.assertEqual(6, source.instances.get_file.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Several command-line/runtime helpers could silently use module globals instead of their injected clients, treat `"false"` as enabled, terminate their host process on recoverable failures, corrupt synchronization checkpoints during an interrupted write, or mask the original monitor-handler exception with a logging-format error.

## What changed

- parse destructive comparator flags with strict, documented boolean values
- consistently use injected Orthanc clients in the uploader and warmer
- raise actionable exceptions after retry exhaustion instead of calling `exit`
- make synchronization checkpoint updates atomic and repair malformed checkpoints
- handle empty synchronization sources and empty transfer batches
- honor the configured synchronization schedule before each query batch
- skip directories in the old-file deleter and make worker shutdown interruptible
- preserve monitor-handler exceptions in logs instead of raising a formatting error
- add focused regression coverage for each corrected behavior

## Operational impact

Invalid boolean configuration now fails at startup instead of enabling an action accidentally. Runtime failures propagate to the process supervisor with a non-success status. Existing valid checkpoint files retain the same two-line timestamp format. Monitor failures now retain the original traceback.

## Checks

- `python -m unittest tests.test_runtime_correctness tests.test_old_files_deleter`: 16 passed
- selected synchronizer/comparator tests against a disposable local three-Orthanc Compose stack: 3 passed
- production-style Docker image build: passed
- `git diff --cached --check`: passed

No production host was contacted and nothing was deployed.
