### PR TITLE
Make CI and releases safe by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.14"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel build
+          python -m pip install -r requirements.txt
+
+      - name: Validate package metadata
+        run: python setup.py egg_info
+
+      - name: Run unit tests
+        run: |
+          python -m unittest orthanc_tools.hl7Lib.tests.test_hl7_folder_monitor
+          python -m unittest orthanc_tools.hl7Lib.tests.test_hl7_message_parser
+          python -m unittest orthanc_tools.hl7Lib.tests.test_hl7_orm_worklist_msg_handler
+          python -m unittest orthanc_tools.hl7Lib.tests.test_hl7_server
+          python -m unittest orthanc_tools.hl7Lib.tests.test_hl7_validator
+          python -m unittest orthanc_tools.hl7Lib.tests.test_hl7_worklist_parser
+          python -m unittest tests/test_old_files_deleter.py
+
+      - name: Build distributions
+        run: python -m build .
+
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel build
+          python -m pip install -r requirements.txt
+
+      - name: Validate package and HL7 behavior
+        run: |
+          python setup.py egg_info
+          python -m unittest discover -s orthanc_tools/hl7Lib/tests
+          python -m unittest tests/test_old_files_deleter.py
+          python -m unittest tests/test_label_modifier.py
+
+      - name: Run three-Orthanc integration tests
+        run: python -m unittest tests/test_3_orthancs.py
+
+      - name: Run replicator integration tests
+        run: python -m unittest tests/test_orthanc_replicator.py
+
+      - name: Build distributions
+        run: python -m build .
+
+      - name: Build production image
+        run: docker build --tag python-orthanc-tools:ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,50 +2,61 @@ name: Release
 
 on:
   push:
-    branches:
-      - '*'
     tags:
-      - '*'
+      - "*"
+
+permissions:
+  contents: read
 
 jobs:
+  tests:
+    uses: ./.github/workflows/ci.yml
+
   build-and-publish:
+    needs: tests
     runs-on: ubuntu-latest
 
     # from https://docs.pypi.org/trusted-publishers/using-a-publisher/
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
     permissions:
+      contents: read
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.x'
+        python-version: "3.14"
 
-    - name: Run python tests
+    - name: Install build dependencies
+      run: python -m pip install --upgrade pip setuptools wheel build
+
+    - name: Verify tag matches package version
+      shell: bash
       run: |
-        pip install setuptools
-        python setup.py egg_info
-        pip install -r requirements.txt
-        python -m unittest discover -s orthanc_tools/hl7Lib/tests
-        python -m unittest tests/test_3_orthancs.py
-        python -m unittest tests/test_old_files_deleter.py
-        python -m unittest tests/test_orthanc_replicator.py
+        package_version="$(python setup.py --version)"
+        if [[ "${GITHUB_REF_NAME}" != "${package_version}" ]]; then
+          echo "Tag ${GITHUB_REF_NAME} does not match package version ${package_version}" >&2
+          exit 1
+        fi
+
+    - name: Build distributions
+      run: python -m build .
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Extract metadata (tags, labels) for Docker (python-orthanc-tools)
       id: meta-python-orthanc-tools
-      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      uses: docker/metadata-action@v6
       with:
         images: orthancteam/python-orthanc-tools
         labels: |
@@ -53,7 +64,7 @@ jobs:
           org.opencontainers.image.vendor=Orthanc Team SRL
 
     - name: Build and push python-orthanc-tools Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: Dockerfile
@@ -61,20 +72,7 @@ jobs:
         tags: ${{ steps.meta-python-orthanc-tools.outputs.tags }}
         labels: ${{ steps.meta-python-orthanc-tools.outputs.labels }}
 
-    - name: Install build dependencies
-      run: python -m pip install -U setuptools wheel build
-
-    - name: Build
-      run: python -m build .
-
-    - name: Publish
+    - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip-existing: true
-
-    # - name: Setup tmate session
-    #   if: ${{ failure() }}
-    #   uses: mxschmitt/action-tmate@v3
-    #   timeout-minutes: 60
-    #   with:
-    #     limit-access-to-actor: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 requests
 orthanc-api-client>=0.24.3
-pydicom>=3.0.0
+pydicom>=3.0.1
 hl7==0.4.2
 six
 schedule==1.2.0
 pika
 inquirer
 paramiko
+tzdata; sys_platform == "win32"

--- a/setup.py
+++ b/setup.py
@@ -91,9 +91,10 @@ setup(
         # that you indicate you support Python 3. These classifiers are *not*
         # checked by 'pip install'. See instead 'python_requires' below.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         'Programming Language :: Python :: 3 :: Only',
     ],
 
@@ -120,7 +121,7 @@ setup(
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. See
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.8, <4',
+    python_requires='>=3.11, <4',
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
@@ -137,7 +138,8 @@ setup(
         'schedule==1.2.0',
         'pika',
         'inquirer',
-        'paramiko'
+        'paramiko',
+        'tzdata; sys_platform == "win32"'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/tests/docker-setup-auth/docker-compose.yml
+++ b/tests/docker-setup-auth/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   orthanc-a:
-    image: orthancteam/orthanc
+    image: orthancteam/orthanc:26.4.2
     ports: ["10042:8042"]
     environment:
       VERBOSE_STARTUP: "true"
@@ -20,7 +20,7 @@ services:
       ORTHANC__OVERWRITE_INSTANCES: "true"
 
   orthanc-auth-service:
-    image: orthancteam/orthanc-auth-service
+    image: orthancteam/orthanc-auth-service:26.4.0
     ports: ["18000:8000"]
     volumes:
       - ./permissions.json:/orthanc_auth_service/permissions.json
@@ -31,7 +31,7 @@ services:
       SECRET_KEY: "change-me-I-am-a-secret-key"
       ENABLE_KEYCLOAK: "true"
       ENABLE_KEYCLOAK_API_KEYS: "true"
-      KEYCLOAK_CLIENT_SECRET: "NPtsEUenl6nw8gJmM886TbvzuGPzvgt9"
+      KEYCLOAK_CLIENT_SECRET: "THPRqk7LVRVxsxcNnOos3cjtLDfIfh0C"
       PUBLIC_ORTHANC_ROOT: "http://orthanc-a:8042/"
       PUBLIC_LANDING_ROOT: "http://orthanc-a:8042/ui/app/token-landing.html"
       USERS: |
@@ -61,7 +61,7 @@ services:
       retries: 10
 
   keycloak:
-    image: orthancteam/orthanc-keycloak
+    image: orthancteam/orthanc-keycloak:26.4.0
     depends_on: [keycloak-db]
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: "admin"

--- a/tests/docker-setup-replicator/docker-compose.yml
+++ b/tests/docker-setup-replicator/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   orthanc-a:
-    image: orthancteam/orthanc
+    image: orthancteam/orthanc:26.4.2
     depends_on:
       broker:
         condition: service_healthy
@@ -23,7 +23,7 @@ services:
 
 
   orthanc-b:
-    image: orthancteam/orthanc
+    image: orthancteam/orthanc:26.4.2
     ports: ["10043:8042"]
     environment:
       VERBOSE_STARTUP: "true"

--- a/tests/docker-setup/docker-compose.yml
+++ b/tests/docker-setup/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   orthanc-a:
-    image: orthancteam/orthanc
+    image: orthancteam/orthanc:26.4.2
     ports: ["10042:8042"]
     environment:
       VERBOSE_STARTUP: "true"
@@ -36,7 +36,7 @@ services:
         }
 
   orthanc-b:
-    image: orthancteam/orthanc
+    image: orthancteam/orthanc:26.4.2
     ports: ["10043:8042"]
     environment:
       VERBOSE_STARTUP: "true"
@@ -73,7 +73,7 @@ services:
         }
 
   orthanc-c:
-    image: orthancteam/orthanc
+    image: orthancteam/orthanc:26.4.2
     ports: ["10044:8042"]
     environment:
       VERBOSE_STARTUP: "true"

--- a/tests/test_label_modifier.py
+++ b/tests/test_label_modifier.py
@@ -167,15 +167,24 @@ class TestLabelModifier(unittest.TestCase):
         subprocess.run(["docker", "compose", "down", "-v"], cwd=here/"docker-setup-auth")
 
     @classmethod
-    def wait_auth_service_started(cls, url, auth):
-        ready = False
-        while not ready:
+    def wait_auth_service_started(cls, url, auth, timeout=120):
+        deadline = time.monotonic() + timeout
+        last_status_code = None
+
+        while time.monotonic() < deadline:
             try:
                 response = requests.get(url=url + "/settings/roles", auth=auth)
                 if response.status_code == 200:
-                    ready = True
-            except Exception as ex:
-                time.sleep(1)
+                    return
+                last_status_code = response.status_code
+            except requests.RequestException:
+                pass
+            time.sleep(1)
+
+        raise TimeoutError(
+            f"Authorization service did not become ready within {timeout} seconds "
+            f"(last status: {last_status_code})"
+        )
 
     def sorting(self, item):
         if isinstance(item, dict):

--- a/tests/test_orthanc_replicator.py
+++ b/tests/test_orthanc_replicator.py
@@ -23,20 +23,27 @@ class TestOrthancReplicator(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        subprocess.run(["docker", "compose", "down", "-v"], cwd=here/"docker-setup-replicator")
-        subprocess.run(["docker", "compose", "up", "-d"], cwd=here/"docker-setup-replicator")
+        compose_dir = here / "docker-setup-replicator"
+        subprocess.run(["docker", "compose", "down", "-v"], cwd=compose_dir)
+        subprocess.run(["docker", "compose", "up", "-d"], cwd=compose_dir, check=True)
 
-        cls.oa = OrthancApiClient('http://localhost:10042', user='test', pwd='test')
-        cls.oa.wait_started()
-        cls.ob = OrthancApiClient('http://localhost:10043', user='test', pwd='test')
-        cls.ob.wait_started()
+        try:
+            cls.oa = OrthancApiClient('http://localhost:10042', user='test', pwd='test')
+            cls.oa.wait_started()
+            cls.ob = OrthancApiClient('http://localhost:10043', user='test', pwd='test')
+            cls.ob.wait_started()
+            helpers.wait_until(cls.rabbitmq_is_ready, 30)
+        except Exception:
+            subprocess.run(["docker", "compose", "down", "-v"], cwd=compose_dir)
+            raise
 
     @classmethod
     def tearDownClass(cls):
         subprocess.run(["docker", "compose", "down", "-v"], cwd=here/"docker-setup-replicator")
 
-    def get_rabbitmq_connection_params(self):
-        broker_connection_parameters = pika.ConnectionParameters(
+    @staticmethod
+    def get_rabbitmq_connection_params():
+        return pika.ConnectionParameters(
             "localhost", 5672,
             credentials=pika.PlainCredentials("rabbit", "123456"),
             connection_attempts=3,
@@ -45,7 +52,15 @@ class TestOrthancReplicator(unittest.TestCase):
             stack_timeout=None,
             blocked_connection_timeout=None
         )
-        return broker_connection_parameters
+
+    @classmethod
+    def rabbitmq_is_ready(cls):
+        try:
+            connection = pika.BlockingConnection(cls.get_rabbitmq_connection_params())
+            connection.close()
+            return True
+        except pika.exceptions.AMQPError:
+            return False
 
     def get_queue_length(self, queue: str, standby: bool):
         pika_conn_params = self.get_rabbitmq_connection_params()
@@ -100,21 +115,23 @@ class TestOrthancReplicator(unittest.TestCase):
         connection.close()
 
     def get_number_of_running_containers(self):
-        bash_cmd = "docker ps | tail -n +2 | wc -l"
-        running_containers = int(subprocess.check_output(bash_cmd, shell=True))
-        return running_containers
+        container_ids = subprocess.check_output(
+            ["docker", "ps", "--quiet"],
+            text=True
+        )
+        return len(container_ids.splitlines())
 
     def stop_container(self, container_name: str):
-        bash_cmd = f"docker stop {container_name}"
-        subprocess.check_output(bash_cmd, shell=True)
+        subprocess.run(["docker", "stop", container_name], check=True)
 
     def start_container(self, container_name: str):
-        bash_cmd = f"docker start {container_name}"
-        subprocess.check_output(bash_cmd, shell=True)
+        subprocess.run(["docker", "start", container_name], check=True)
 
     def get_container_status(self, container_name: str):
-        bash_cmd = f"docker inspect --format={{{{.State.Health.Status}}}} {container_name}"
-        return subprocess.check_output(bash_cmd, shell=True)
+        return subprocess.check_output(
+            ["docker", "inspect", "--format={{.State.Health.Status}}", container_name],
+            text=True
+        ).strip()
 
     def test_forward_and_delete_instance(self):
 
@@ -258,7 +275,7 @@ class TestOrthancReplicator(unittest.TestCase):
         helpers.wait_until(lambda: self.get_number_of_running_containers() == 3, 10)
 
         # and until the broker is ready to accept connections
-        helpers.wait_until(lambda: str(self.get_container_status("broker")) == "healthy", 15)
+        helpers.wait_until(lambda: self.get_container_status("broker") == "healthy", 15)
 
         # check that everything is now ok by deleting the instance from the orthanc source
         self.oa.delete_all_content()


### PR DESCRIPTION
## Why

The release workflow currently publishes Docker and PyPI artifacts on every branch push, before a tag or version assertion. The test setup also relies on mutable service images, has unbounded readiness waits, and declares Python versions that the current dependency set cannot install on.

## What changed

- add a reusable CI workflow for pull requests, branch pushes, and release gating
- restrict publishing to tags, require the tag to match the package version, and grant least-privilege workflow permissions
- test the actual supported range (Python 3.11 and the production Python 3.14 runtime)
- align package metadata with the current `pydicom` and `orthanc-api-client` runtime requirements
- add Windows timezone data only where it is needed
- pin disposable Orthanc/auth test stacks to known versions
- bound authorization-service startup and make replicator Docker checks portable and race-free
- update the release actions to their maintained major versions

## Local checks

- Python 3.11 compatibility image: 35 unit tests plus sdist/wheel build
- Python 3.14 production image build
- Linux/Python 3.14 HL7 suite: 36 tests
- three-Orthanc Docker suite: 40 tests in 615.5s, including high-volume transfers
- authorization Docker suite: 3 tests
- replicator Docker suite: 4 tests, including broker loss/recovery
- isolated local sdist/wheel build
- all three Compose files parsed successfully
- `git diff --check`

No production service or `mp-docker` host was contacted or changed.
