### PR TITLE
Make PostgreSQL backups atomic

### DIFF
--- a/orthanc_tools/postgres_dumper.py
+++ b/orthanc_tools/postgres_dumper.py
@@ -1,12 +1,19 @@
-import sys
+import gzip
 import datetime
-import paramiko
-import time, os
 import argparse
 import logging
-import schedule
+import os
+import posixpath
 import subprocess
+import tempfile
+import time
+import uuid
+
+import paramiko
+import schedule
+
 logger = logging.getLogger(__name__)
+
 
 class PostgresDumper:
     """
@@ -16,77 +23,120 @@ class PostgresDumper:
     `postgresql-client` has to be installed before the execution of this script
 
     To restore:
-    pg_restore --clean -U postgres -h 172.21.0.3 -p 5432 -d postgres Friday
+    gzip -dc Friday.gz | pg_restore --clean -U postgres -h database -p 5432 -d postgres
     """
     def __init__(self, pg_host: str, pg_port: str, pg_db_name: str, pg_user_name: str, pg_password,
                  execution_time: str,
-                 sftp_host: int, sftp_port: str, sftp_user_name: str, sftp_password: str, sftp_folder_path: str
+                 sftp_host: str, sftp_port: int, sftp_user_name: str, sftp_password: str, sftp_folder_path: str
                  ):
 
-        self.sftp_folder_path = sftp_folder_path
-        # remove last char if this is a slash
-        if self.sftp_folder_path[-1:] == '/':
-            self.sftp_folder_path = self.sftp_folder_path[:-1]
+        if not sftp_host:
+            raise ValueError("sftp_host must be configured")
+        if not sftp_user_name:
+            raise ValueError("sftp_user_name must be configured")
+        if not sftp_folder_path:
+            raise ValueError("sftp_folder_path must be configured")
+
+        self.sftp_folder_path = sftp_folder_path.rstrip("/") or "/"
         self.sftp_password = sftp_password
         self.sftp_user_name = sftp_user_name
-        self.sftp_port = sftp_port
+        self.sftp_port = int(sftp_port)
         self.sftp_host = sftp_host
         self.execution_time = execution_time
         self.pg_password = pg_password
         self.pg_user_name = pg_user_name
         self.pg_db_name = pg_db_name
         self.pg_host = pg_host
-        self.pg_port = pg_port
+        self.pg_port = str(pg_port)
+
+    def _stream_compressed_dump(self, remote_file):
+        stderr_file = tempfile.TemporaryFile()
+        process = None
+
+        try:
+            process = subprocess.Popen(
+                [
+                    "pg_dump",
+                    "-U", self.pg_user_name,
+                    "-h", self.pg_host,
+                    "-p", self.pg_port,
+                    "-Fc",
+                    self.pg_db_name,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=stderr_file,
+                env={**os.environ, "PGPASSWORD": self.pg_password},
+            )
+
+            with gzip.GzipFile(fileobj=remote_file, mode="wb", mtime=0) as compressed_file:
+                for chunk in iter(lambda: process.stdout.read(64 * 1024), b""):
+                    compressed_file.write(chunk)
+
+            return_code = process.wait()
+            stderr_file.seek(0)
+            error_message = stderr_file.read().decode(errors="replace").strip()
+
+            if return_code != 0:
+                raise RuntimeError(
+                    f"pg_dump failed with exit code {return_code}: {error_message}"
+                )
+        except Exception:
+            if process is not None and process.poll() is None:
+                process.terminate()
+                process.wait()
+            raise
+        finally:
+            if process is not None and process.stdout is not None:
+                process.stdout.close()
+            stderr_file.close()
 
     def stream_pg_dump_to_sftp(self):
+        transport = None
+        sftp = None
+
+        day_file_name = f"{datetime.date.today().strftime('%A')}.gz"
+        final_file_path = posixpath.join(self.sftp_folder_path, day_file_name)
+        temporary_file_path = f"{final_file_path}.part-{uuid.uuid4().hex}"
+
         try:
-            # Establish SFTP connection
             transport = paramiko.Transport((self.sftp_host, self.sftp_port))
-            transport.connect(username=self.sftp_user_name, password=self.sftp_password)
+            transport.connect(
+                username=self.sftp_user_name,
+                password=self.sftp_password,
+            )
             sftp = paramiko.SFTPClient.from_transport(transport)
 
-            # Build full file path: we use the name fo the day, so that only 7 files are kept and there is no need
-            # to clean up ourselves (files are overwritten the next week)
-            sftp_file_path = f"{self.sftp_folder_path}/{datetime.date.today().strftime('%A')}.gz"
+            with sftp.open(temporary_file_path, "wb") as remote_file:
+                self._stream_compressed_dump(remote_file)
 
-            # Open a remote file for writing
-            # TODO: given that the 'sftp.open()' works the same way as a regular file, we could make this script working for both cases
-            with sftp.open(sftp_file_path, "wb") as remote_file:
-                # Run pg_dump and capture output
-                # Let's be honest, ChatGPT helped a lot on this ;-)
-                process = subprocess.Popen(
-                    ["pg_dump", "-U", self.pg_user_name, "-h", self.pg_host, "-p", self.pg_port, "-Fc", self.pg_db_name],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    env={"PGPASSWORD": self.pg_password}
-                )
+            try:
+                sftp.posix_rename(temporary_file_path, final_file_path)
+            except OSError as ex:
+                raise RuntimeError(
+                    "The SFTP server could not atomically promote the completed "
+                    f"backup to {final_file_path}; the previous backup was preserved"
+                ) from ex
 
-                # Compress the dump (the 'Fc' parameter of the pg_dump command is not very efficient)
-                gzip_process = subprocess.Popen(["gzip"], stdin=process.stdout, stdout=subprocess.PIPE)
-
-                # Stream gzip output directly to SFTP
-                for chunk in iter(lambda: gzip_process.stdout.read(4096), b""):
-                    remote_file.write(chunk)
-
-                # Ensure the process completes
-                process.stdout.close()
-                process.wait()
-
-                # Check for errors
-                if process.returncode != 0:
-                    error_message = process.stderr.read().decode()
-                    logger.error(f"pg_dump failed: {error_message}")
-
-            logger.info(f"Backup successfully uploaded to {self.sftp_folder_path}")
-
-        except Exception as e:
-            logger.error(f"Error: {e}")
-            sys.exit(-1)
-
+            logger.info("Backup successfully uploaded to %s", final_file_path)
+        except Exception:
+            if sftp is not None and temporary_file_path is not None:
+                try:
+                    sftp.remove(temporary_file_path)
+                except OSError:
+                    pass
+            logger.exception("PostgreSQL backup failed")
+            raise
         finally:
-            sftp.close()
-            transport.close()
-
+            if sftp is not None:
+                try:
+                    sftp.close()
+                except Exception:
+                    logger.warning("Could not close SFTP client", exc_info=True)
+            if transport is not None:
+                try:
+                    transport.close()
+                except Exception:
+                    logger.warning("Could not close SFTP transport", exc_info=True)
 
     def execute(self):
         logger.info("----- Initializing Postgres Dumper...")
@@ -95,9 +145,10 @@ class PostgresDumper:
         try:
             result = subprocess.run(["pg_dump", "--version"], capture_output=True, text=True, check=True)
             logger.info(f"pg_dump version: {result.stdout.strip()}")
-        except FileNotFoundError:
-            logger.error("it seems that pg_dump is NOT installed, plase install it before running this script (apt install postgresql-client)")
-            sys.exit(-1)
+        except (FileNotFoundError, subprocess.CalledProcessError) as ex:
+            raise RuntimeError(
+                "pg_dump is unavailable; install postgresql-client before running this tool"
+            ) from ex
 
         if self.execution_time is None:
             # unit test case
@@ -117,7 +168,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=level, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
     parser = argparse.ArgumentParser(description='Periodically dumps Postgres DB to an SFTP server.')
-    parser.add_argument('--pg_host', type=str, default='http://orthanc-db', help='Postgres hostname')
+    parser.add_argument('--pg_host', type=str, default='orthanc-db', help='Postgres hostname')
     parser.add_argument('--pg_port', type=str, default='5432', help='Postgres port number')
     parser.add_argument('--pg_db_name', type=str, default='postgres', help='Postgres database name')
     parser.add_argument('--pg_user_name', type=str, default='postgres', help='Postgres username')
@@ -136,7 +187,7 @@ if __name__ == '__main__':
     pg_user_name = os.environ.get("PG_USER_NAME", args.pg_user_name)
     pg_password = os.environ.get("PG_PASSWORD", args.pg_password)
     execution_time = os.environ.get("EXECUTION_TIME", args.execution_time)
-    if execution_time is '':
+    if execution_time == '':
         execution_time = None
     sftp_host = os.environ.get("SFTP_HOST", args.sftp_host)
     sftp_port = int(os.environ.get("SFTP_PORT", args.sftp_port))

--- a/tests/test_postgres_dumper.py
+++ b/tests/test_postgres_dumper.py
@@ -1,0 +1,181 @@
+import gzip
+import io
+import os
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from orthanc_tools.postgres_dumper import PostgresDumper
+
+
+class NonClosingBytesIO(io.BytesIO):
+    def close(self):
+        self.flushed_on_close = True
+
+
+class FakeProcess:
+    def __init__(self, stdout, return_code):
+        self.stdout = io.BytesIO(stdout)
+        self._configured_return_code = return_code
+        self.returncode = None
+        self.terminated = False
+
+    def wait(self):
+        self.returncode = self._configured_return_code
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -1
+
+
+class TestPostgresDumper(unittest.TestCase):
+    def setUp(self):
+        self.dumper = PostgresDumper(
+            pg_host="database",
+            pg_port=5432,
+            pg_db_name="orthanc",
+            pg_user_name="backup",
+            pg_password="database-secret",
+            execution_time=None,
+            sftp_host="backup",
+            sftp_port=22,
+            sftp_user_name="uploader",
+            sftp_password="sftp-secret",
+            sftp_folder_path="/backups/",
+        )
+
+        self.transport = mock.MagicMock()
+        self.sftp = mock.MagicMock()
+        self.remote_file = NonClosingBytesIO()
+        self.sftp.open.return_value = self.remote_file
+
+        self.transport_patch = mock.patch(
+            "orthanc_tools.postgres_dumper.paramiko.Transport",
+            return_value=self.transport,
+        )
+        self.sftp_patch = mock.patch(
+            "orthanc_tools.postgres_dumper.paramiko.SFTPClient.from_transport",
+            return_value=self.sftp,
+        )
+        self.uuid_patch = mock.patch(
+            "orthanc_tools.postgres_dumper.uuid.uuid4",
+            return_value=SimpleNamespace(hex="test-run"),
+        )
+        self.transport_patch.start()
+        self.sftp_patch.start()
+        self.uuid_patch.start()
+        self.addCleanup(self.transport_patch.stop)
+        self.addCleanup(self.sftp_patch.stop)
+        self.addCleanup(self.uuid_patch.stop)
+
+    def _popen(self, dump, return_code=0, stderr=b"", captured_env=None):
+        def create_process(*args, **kwargs):
+            kwargs["stderr"].write(stderr)
+            if captured_env is not None:
+                captured_env.update(kwargs["env"])
+            return FakeProcess(dump, return_code)
+
+        return create_process
+
+    def test_successful_dump_is_compressed_then_atomically_promoted(self):
+        dump = b"postgres custom-format dump"
+        captured_env = {}
+
+        with mock.patch.dict(os.environ, {"PATH": "test-path"}, clear=True):
+            with mock.patch(
+                "orthanc_tools.postgres_dumper.subprocess.Popen",
+                side_effect=self._popen(dump, captured_env=captured_env),
+            ):
+                self.dumper.stream_pg_dump_to_sftp()
+
+        temporary_path = self.sftp.open.call_args.args[0]
+        final_path = self.sftp.posix_rename.call_args.args[1]
+        self.assertTrue(temporary_path.endswith(".gz.part-test-run"))
+        self.assertTrue(final_path.startswith("/backups/"))
+        self.assertTrue(final_path.endswith(".gz"))
+        self.assertEqual(dump, gzip.decompress(self.remote_file.getvalue()))
+        self.assertEqual("test-path", captured_env["PATH"])
+        self.assertEqual("database-secret", captured_env["PGPASSWORD"])
+        self.sftp.posix_rename.assert_called_once_with(
+            temporary_path,
+            final_path,
+        )
+        self.sftp.remove.assert_not_called()
+        self.sftp.close.assert_called_once_with()
+        self.transport.close.assert_called_once_with()
+
+    def test_failed_pg_dump_removes_partial_file_and_preserves_final_name(self):
+        self.sftp.close.side_effect = OSError("close failed")
+
+        with mock.patch(
+            "orthanc_tools.postgres_dumper.subprocess.Popen",
+            side_effect=self._popen(
+                b"incomplete",
+                return_code=1,
+                stderr=b"permission denied",
+            ),
+        ):
+            with self.assertLogs(
+                "orthanc_tools.postgres_dumper",
+                level="ERROR",
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "pg_dump failed with exit code 1: permission denied",
+                ):
+                    self.dumper.stream_pg_dump_to_sftp()
+
+        temporary_path = self.sftp.open.call_args.args[0]
+        self.sftp.remove.assert_called_once_with(temporary_path)
+        self.sftp.posix_rename.assert_not_called()
+
+    def test_failed_atomic_promotion_keeps_previous_backup(self):
+        self.sftp.posix_rename.side_effect = OSError("unsupported")
+
+        with mock.patch(
+            "orthanc_tools.postgres_dumper.subprocess.Popen",
+            side_effect=self._popen(b"complete dump"),
+        ):
+            with self.assertLogs(
+                "orthanc_tools.postgres_dumper",
+                level="ERROR",
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "previous backup was preserved",
+                ):
+                    self.dumper.stream_pg_dump_to_sftp()
+
+        temporary_path = self.sftp.open.call_args.args[0]
+        self.sftp.remove.assert_called_once_with(temporary_path)
+
+    def test_connection_error_is_not_masked_by_cleanup(self):
+        self.transport_patch.stop()
+
+        with mock.patch(
+            "orthanc_tools.postgres_dumper.paramiko.Transport",
+            side_effect=OSError("offline"),
+        ):
+            with self.assertLogs(
+                "orthanc_tools.postgres_dumper",
+                level="ERROR",
+            ):
+                with self.assertRaisesRegex(OSError, "offline"):
+                    self.dumper.stream_pg_dump_to_sftp()
+
+    def test_missing_pg_dump_raises_runtime_error(self):
+        with mock.patch(
+            "orthanc_tools.postgres_dumper.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "pg_dump is unavailable"):
+                self.dumper.execute()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The dumper wrote directly over the weekly SFTP backup, did not wait for or validate gzip, logged success after a failed `pg_dump`, and could mask the original failure during cleanup. A failed run could therefore leave a truncated file under the normal backup name while appearing successful.

## What changed

- stream `pg_dump` through Python gzip into a uniquely named remote partial file
- check the real `pg_dump` exit status and preserve stderr without risking a pipe deadlock
- atomically promote a completed file with the SFTP POSIX rename extension
- remove partial files on failure while leaving the previous weekly backup untouched
- preserve the parent environment when adding `PGPASSWORD`
- close partially initialized SFTP resources safely without masking the primary error
- raise runtime errors instead of terminating the host interpreter
- validate required SFTP settings and correct the default PostgreSQL hostname
- fix empty execution-time comparison and restore documentation

The atomic promotion intentionally fails closed when the SFTP server does not support the POSIX rename extension; it will not delete the previous known-good backup to work around that limitation.

## Local checks

- 5 focused unit/failure-path tests
- disposable PostgreSQL 17 + OpenSSH/SFTP + Python 3.14 Docker integration
- seeded database dumped with real `pg_dump`
- uploaded gzip contained no leftover `.part-*` file
- decompressed artifact validated with `pg_restore --list`
- production image build
- sdist/wheel build
- Python compile check
- `git diff --check`

No production service or `mp-docker` host was contacted or changed.
